### PR TITLE
fix: retry getting log stream when getting EOF error at E2E test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
           curl -L https://github.com/nats-io/nats-server/releases/download/v$JS_VERSION/nats-server-v$JS_VERSION-linux-amd64.zip -o nats-server.zip
           sudo unzip nats-server.zip -d nats-server
           nats-server/nats-server-v$JS_VERSION-linux-amd64/nats-server -js &
-      - name: Insall Redis
+      - name: Install Redis
         uses: shogo82148/actions-setup-redis@v1
         with:
           redis-version: "6.2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,10 +139,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         driver: [jetstream]
-        case: [e2e, kafka-e2e, http-e2e]
+        case: [e2e, kafka-e2e, http-e2e, sdks-e2e]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,9 @@ on:
     branches:
       - "main"
       - "release-*"
+      - "flaky-e2e"
   pull_request:
-    branches: [main]
+    branches: [flaky-e2e, main]
 jobs:
   ui:
     name: UI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,7 +139,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 4
       matrix:
         driver: [jetstream]
         case: [e2e, kafka-e2e, http-e2e, sdks-e2e]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
       max-parallel: 4
       matrix:
         driver: [jetstream]
-        case: [e2e, kafka-e2e, http-e2e, sdks-e2e]
+        case: [e2e, kafka-e2e, http-e2e]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
       max-parallel: 4
       matrix:
         driver: [jetstream]
-        case: [e2e, kafka-e2e, http-e2e]
+        case: [e2e, kafka-e2e, http-e2e, sdks-e2e]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,8 @@ on:
     branches:
       - "main"
       - "release-*"
-      - "flaky-e2e"
   pull_request:
-    branches: [flaky-e2e, main]
+    branches: [main]
 jobs:
   ui:
     name: UI

--- a/test/fixtures/expect.go
+++ b/test/fixtures/expect.go
@@ -80,10 +80,10 @@ func (t *Expect) VertexPodLogContains(vertexName, regex string, opts ...PodLogCh
 	ctx := context.Background()
 	contains, err := VertexPodLogContains(ctx, t.kubeClient, Namespace, t.pipeline.Name, vertexName, regex, opts...)
 	if err != nil {
-		t.t.Fatalf("Failed to check vertex pod logs: %v", err)
+		t.t.Fatalf("Failed to check vertex %q pod logs: %v", vertexName, err)
 	}
 	if !contains {
-		t.t.Fatalf("Expected vertex pod log contains %q", regex)
+		t.t.Fatalf("Expected vertex %q pod log contains %q", vertexName, regex)
 	}
 	return t
 }
@@ -96,7 +96,7 @@ func (t *Expect) VertexPodLogNotContains(vertexName, regex string, opts ...PodLo
 		t.t.Fatalf("Failed to check vertex pod logs: %v", err)
 	}
 	if !yes {
-		t.t.Fatalf("Not expected vertex pod log contains %q", regex)
+		t.t.Fatalf("Not expected vertex %q pod log contains %q", vertexName, regex)
 	}
 	return t
 }

--- a/test/fixtures/port_forward.go
+++ b/test/fixtures/port_forward.go
@@ -1,18 +1,22 @@
 package fixtures
 
 import (
+	"context"
 	"fmt"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 )
 
 func PodPortForward(config *rest.Config, namespace, podName string, localPort, remotePort int, stopCh <-chan struct{}) error {
+	ctx := context.Background()
 	readyCh := make(chan struct{})
 
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward",
@@ -37,16 +41,27 @@ func PodPortForward(config *rest.Config, namespace, podName string, localPort, r
 	}
 
 	go func() {
+		var err error
 		// Port forwarding can fail due to transient "error upgrading connection: error dialing backend: EOF" issue.
 		// To prevent such issue, we apply retry strategy.
 		// 3 attempts with 1 second fixed wait time are tested sufficient for it.
-		err := retryOnError(3, time.Duration(1*time.Second), func() error {
-			err := fw.ForwardPorts()
-			if err != nil {
-				fmt.Printf("Got error %v, retrying.\n", err)
+		var retryBackOff = wait.Backoff{
+			Factor:   1,
+			Jitter:   0,
+			Steps:    3,
+			Duration: time.Second * 1,
+		}
+
+		_ = wait.ExponentialBackoffWithContext(ctx, retryBackOff, func() (done bool, err error) {
+			err = fw.ForwardPorts()
+			if err == nil {
+				return true, nil
 			}
-			return err
+
+			fmt.Printf("Got error %v, retrying.\n", err)
+			return false, nil
 		})
+
 		if err != nil {
 			panic(err)
 		}

--- a/test/fixtures/util.go
+++ b/test/fixtures/util.go
@@ -273,6 +273,7 @@ func PodsLogNotContains(ctx context.Context, kubeClient kubernetes.Interface, na
 	resultChan := make(chan bool)
 	for _, p := range podList.Items {
 		go func(podName string) {
+			fmt.Printf("Watching POD: %s\n", podName)
 			if err := podLogContains(cctx, kubeClient, namespace, podName, o.container, regex, resultChan); err != nil {
 				errChan <- err
 				return
@@ -324,6 +325,7 @@ func PodsLogContains(ctx context.Context, kubeClient kubernetes.Interface, names
 	resultChan := make(chan bool)
 	for _, p := range podList.Items {
 		go func(podName string) {
+			fmt.Printf("Watching POD: %s\n", podName)
 			if err := podLogContains(cctx, kubeClient, namespace, podName, o.container, regex, resultChan); err != nil {
 				errChan <- err
 				return
@@ -354,7 +356,6 @@ func PodsLogContains(ctx context.Context, kubeClient kubernetes.Interface, names
 }
 
 func podLogContains(ctx context.Context, client kubernetes.Interface, namespace, podName, containerName, regex string, result chan bool) error {
-	fmt.Printf("Watching POD: %s\n", podName)
 	var stream io.ReadCloser
 	// Streaming logs from file could be rotated by container log manager and as consequence, we receive EOF and need to re-initialize the stream.
 	// To prevent such issue, we apply retry on stream initialization.
@@ -370,9 +371,7 @@ func podLogContains(ctx context.Context, client kubernetes.Interface, namespace,
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = stream.Close()
-	}()
+	defer func() { _ = stream.Close() }()
 
 	exp, err := regexp.Compile(regex)
 	if err != nil {

--- a/test/fixtures/util.go
+++ b/test/fixtures/util.go
@@ -357,12 +357,17 @@ func PodsLogContains(ctx context.Context, kubeClient kubernetes.Interface, names
 func podLogContains(ctx context.Context, client kubernetes.Interface, namespace, podName, containerName, regex string, result chan bool, errs chan error) error {
 	stream, err := client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Follow: true, Container: containerName}).Stream(ctx)
 	if err != nil {
+		fmt.Printf("KeranTest1 - I am here, getting error: %v", err)
 		return err
 	}
-	defer func() { _ = stream.Close() }()
+	defer func() {
+		fmt.Printf("KeranTest2 - I am here, closing the log stream.")
+		_ = stream.Close()
+	}()
 
 	exp, err := regexp.Compile(regex)
 	if err != nil {
+		fmt.Printf("KeranTest3 - I am here: %v, seems can't compile the regex.", err)
 		return err
 	}
 
@@ -370,6 +375,7 @@ func podLogContains(ctx context.Context, client kubernetes.Interface, namespace,
 	for {
 		select {
 		case <-ctx.Done():
+			fmt.Printf("KeranTest4 - I am here, context is done.")
 			return nil
 		default:
 			if !s.Scan() {

--- a/test/fixtures/util.go
+++ b/test/fixtures/util.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
 	"os/exec"
 	"regexp"
@@ -20,6 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -23,7 +23,7 @@ type When struct {
 	restConfig     *rest.Config
 	kubeClient     kubernetes.Interface
 
-	portForwarderStopChanels map[string]chan struct{}
+	portForwarderStopChannels map[string]chan struct{}
 }
 
 func (w *When) CreateISBSvc() *When {
@@ -135,10 +135,10 @@ func (w *When) VertexPodPortForward(vertexName string, localPort, remotePort int
 	if err = PodPortForward(w.restConfig, Namespace, podName, localPort, remotePort, stopCh); err != nil {
 		w.t.Fatalf("Expected vertex pod port-forward: %v", err)
 	}
-	if w.portForwarderStopChanels == nil {
-		w.portForwarderStopChanels = make(map[string]chan struct{})
+	if w.portForwarderStopChannels == nil {
+		w.portForwarderStopChannels = make(map[string]chan struct{})
 	}
-	w.portForwarderStopChanels[podName] = stopCh
+	w.portForwarderStopChannels[podName] = stopCh
 	return w
 }
 
@@ -157,17 +157,17 @@ func (w *When) DaemonPodPortForward(pipelineName string, localPort, remotePort i
 	if err = PodPortForward(w.restConfig, Namespace, podName, localPort, remotePort, stopCh); err != nil {
 		w.t.Fatalf("Expected daemon pod port-forward: %v", err)
 	}
-	if w.portForwarderStopChanels == nil {
-		w.portForwarderStopChanels = make(map[string]chan struct{})
+	if w.portForwarderStopChannels == nil {
+		w.portForwarderStopChannels = make(map[string]chan struct{})
 	}
-	w.portForwarderStopChanels[podName] = stopCh
+	w.portForwarderStopChannels[podName] = stopCh
 	return w
 }
 
 func (w *When) TerminateAllPodPortForwards() *When {
 	w.t.Helper()
-	if len(w.portForwarderStopChanels) > 0 {
-		for k, v := range w.portForwarderStopChanels {
+	if len(w.portForwarderStopChannels) > 0 {
+		for k, v := range w.portForwarderStopChannels {
 			w.t.Logf("Terminating port-forward for POD %s", k)
 			close(v)
 		}

--- a/test/sdks-e2e/README.md
+++ b/test/sdks-e2e/README.md
@@ -4,4 +4,4 @@ Each SDK is supposed to implement:
 
 1. A `flatmap` UDF example, which splits the input message with `,`, and return a list. Build a docker image `quay.io/numaio/flatmap-example:${language}` and push to `quay.io`;
    
-2. A `simplesink` UDSink example, which prints out origal message in pod logs. Build a docker image `quay.io/numaio/simplesink-example:${language}` and push to `quay.io`.
+2. A `simplesink` UDSink example, which prints out original message in pod logs. Build a docker image `quay.io/numaio/simplesink-example:${language}` and push to `quay.io`.

--- a/test/sdks-e2e/README.md
+++ b/test/sdks-e2e/README.md
@@ -4,4 +4,4 @@ Each SDK is supposed to implement:
 
 1. A `flatmap` UDF example, which splits the input message with `,`, and return a list. Build a docker image `quay.io/numaio/flatmap-example:${language}` and push to `quay.io`;
    
-2. A `simplesink` UDSink example, which prints out original message in pod logs. Build a docker image `quay.io/numaio/simplesink-example:${language}` and push to `quay.io`.
+2. A `simplesink` UDSink example, which prints out origal message in pod logs. Build a docker image `quay.io/numaio/simplesink-example:${language}` and push to `quay.io`.


### PR DESCRIPTION
By adding retrying logic on getting pod log stream, I was able to resolve the EOF error.

```
Watching POD: simple-pipeline-watermark-cat3-0-np6xu
error: Get "https://172.18.0.3:10250/containerLogs/numaflow-system/simple-pipeline-watermark-cat3-0-np6xu/main?follow=true": EOF    functional_test.go:180: Expected vertex pod log contains "Start processing udf messages"
```

### Testing
The following E2E test runs show in the log that the retry is getting invoked, which helps passing the E2E tests.
https://github.com/KeranYang/numaflow/actions/runs/3332300161/jobs/5513175775
https://github.com/KeranYang/numaflow/actions/runs/3332300028/jobs/5513170308

Signed-off-by: Keran Yang <yangkr920208@gmail.com>


<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
