### PR TITLE
fix: skip empty Kafka partitions when calculating pending count

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,13 +30,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 
-	"github.com/numaproj/numaflow/pkg/shared/util"
-
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	sharedqueue "github.com/numaproj/numaflow/pkg/shared/queue"
 	sharedtls "github.com/numaproj/numaflow/pkg/shared/tls"
+	"github.com/numaproj/numaflow/pkg/shared/util"
 )
 
 const (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -25,11 +25,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/numaproj/numaflow/pkg/shared/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
+
+	"github.com/numaproj/numaflow/pkg/shared/util"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/isb"
@@ -171,7 +172,7 @@ func NewMetricsServer(vertex *dfv1.Vertex, opts ...Option) *metricsServer {
 	return m
 }
 
-// Enqueue pending pending information
+// Enqueue pending information
 func (ms *metricsServer) buildupPendingInfo(ctx context.Context) {
 	if ms.lagReader == nil {
 		return
@@ -187,6 +188,7 @@ func (ms *metricsServer) buildupPendingInfo(ctx context.Context) {
 			if pending, err := ms.lagReader.Pending(ctx); err != nil {
 				log.Errorw("Failed to get pending messages", zap.Error(err))
 			} else {
+				log.Infof("KeranTest - Number of pending messages: %d", pending)
 				if pending != isb.PendingNotAvailable {
 					ts := timestampedPending{pending: pending, timestamp: time.Now().Unix()}
 					ms.pendingInfo.Append(ts)
@@ -224,7 +226,7 @@ func (ms *metricsServer) exposePendingAndRate(ctx context.Context) {
 			}
 			if ms.lagReader != nil {
 				for n, i := range lookbackSecondsMap {
-					if p := ms.calculatePending(i); p != isb.PendingNotAvailable {
+					if p := ms.calculatePending(i, log); p != isb.PendingNotAvailable {
 						pending.WithLabelValues(ms.vertex.Spec.PipelineName, ms.vertex.Spec.Name, n).Set(float64(p))
 					}
 				}
@@ -236,13 +238,16 @@ func (ms *metricsServer) exposePendingAndRate(ctx context.Context) {
 }
 
 // Calculate the avg pending of last seconds
-func (ms *metricsServer) calculatePending(seconds int64) int64 {
+func (ms *metricsServer) calculatePending(seconds int64, log *zap.SugaredLogger) int64 {
+	log.Infof("KeranTest - Calculate pending of last %d seconds", seconds)
 	result := isb.PendingNotAvailable
 	items := ms.pendingInfo.Items()
 	total := int64(0)
 	num := int64(0)
 	now := time.Now().Unix()
+	log.Infof("KeranTest - Current timestamp: %d", now)
 	for i := len(items) - 1; i >= 0; i-- {
+		log.Infof("KeranTest - Pending message: %d, timestamp: %d", items[i].pending, items[i].timestamp)
 		if now-items[i].timestamp < seconds {
 			total += items[i].pending
 			num++
@@ -250,9 +255,11 @@ func (ms *metricsServer) calculatePending(seconds int64) int64 {
 			break
 		}
 	}
+	log.Infof("KeranTest - Total pending: %d, number of timestampedPending: %d", total, num)
 	if num > 0 {
 		result = total / num
 	}
+	log.Infof("KeranTest - Avg pending: %d", result)
 	return result
 }
 

--- a/pkg/reconciler/vertex/scaling/scaling.go
+++ b/pkg/reconciler/vertex/scaling/scaling.go
@@ -216,17 +216,13 @@ func (s *Scaler) scaleOneVertex(ctx context.Context, key string, worker int) err
 	}
 	// Avg rate and pending for autoscaling are both in the map with key "default", see "pkg/metrics/metrics.go".
 	rate, existing := vMetrics[0].ProcessingRates["default"]
-	log.Info("KeranTest - rate: ", rate, " existing: ", existing, " vertex: ", vertex.Name, " key: ", key, " vMetrics: ", vMetrics[0].ProcessingRates["default"])
 	if !existing || rate < 0 || rate == isb.RateNotAvailable { // Rate not available
-		log.Info("KeranTest - rate not available")
 		log.Debugf("Vertex %s has no rate information, skip scaling", vertex.Name)
 		return nil
 	}
 	pending, existing := vMetrics[0].Pendings["default"]
-	log.Info("KeranTest - pending: ", pending, " existing: ", existing, " vertex: ", vertex.Name, " key: ", key, " vMetrics: ", vMetrics[0].Pendings["default"])
 	if !existing || pending < 0 || pending == isb.PendingNotAvailable {
 		// Pending not available, we don't do anything
-		log.Info("KeranTest - pending not available")
 		log.Debugf("Vertex %s has no pending messages information, skip scaling", vertex.Name)
 		return nil
 	}
@@ -249,9 +245,7 @@ func (s *Scaler) scaleOneVertex(ctx context.Context, key string, worker int) err
 		}
 	}
 	current := int32(vertex.GetReplicas())
-	log.Infof("KeranTest - calculating desired replicas, vertex: %s, rate: %f, pending: %d, totalBufferLength: %d, targetAvailableBufferLength: %d", vertex.Name, rate, pending, totalBufferLength, targetAvailableBufferLength)
 	desired := s.desiredReplicas(ctx, vertex, rate, pending, totalBufferLength, targetAvailableBufferLength)
-	log.Infof("KeranTest - current: %d, desired: %d, vertex: %s, key: %s", current, desired, vertex.Name, key)
 	log.Debugf("Calculated desired replica number of vertex %q is: %t", vertex.Name, desired)
 	max := vertex.Spec.Scale.GetMaxReplicas()
 	min := vertex.Spec.Scale.GetMinReplicas()

--- a/pkg/reconciler/vertex/scaling/scaling.go
+++ b/pkg/reconciler/vertex/scaling/scaling.go
@@ -216,13 +216,17 @@ func (s *Scaler) scaleOneVertex(ctx context.Context, key string, worker int) err
 	}
 	// Avg rate and pending for autoscaling are both in the map with key "default", see "pkg/metrics/metrics.go".
 	rate, existing := vMetrics[0].ProcessingRates["default"]
+	log.Info("KeranTest - rate: ", rate, " existing: ", existing, " vertex: ", vertex.Name, " key: ", key, " vMetrics: ", vMetrics[0].ProcessingRates["default"])
 	if !existing || rate < 0 || rate == isb.RateNotAvailable { // Rate not available
+		log.Info("KeranTest - rate not available")
 		log.Debugf("Vertex %s has no rate information, skip scaling", vertex.Name)
 		return nil
 	}
 	pending, existing := vMetrics[0].Pendings["default"]
+	log.Info("KeranTest - pending: ", pending, " existing: ", existing, " vertex: ", vertex.Name, " key: ", key, " vMetrics: ", vMetrics[0].Pendings["default"])
 	if !existing || pending < 0 || pending == isb.PendingNotAvailable {
 		// Pending not available, we don't do anything
+		log.Info("KeranTest - pending not available")
 		log.Debugf("Vertex %s has no pending messages information, skip scaling", vertex.Name)
 		return nil
 	}
@@ -245,7 +249,9 @@ func (s *Scaler) scaleOneVertex(ctx context.Context, key string, worker int) err
 		}
 	}
 	current := int32(vertex.GetReplicas())
+	log.Infof("KeranTest - calculating desired replicas, vertex: %s, rate: %f, pending: %d, totalBufferLength: %d, targetAvailableBufferLength: %d", vertex.Name, rate, pending, totalBufferLength, targetAvailableBufferLength)
 	desired := s.desiredReplicas(ctx, vertex, rate, pending, totalBufferLength, targetAvailableBufferLength)
+	log.Infof("KeranTest - current: %d, desired: %d, vertex: %s, key: %s", current, desired, vertex.Name, key)
 	log.Debugf("Calculated desired replica number of vertex %q is: %t", vertex.Name, desired)
 	max := vertex.Spec.Scale.GetMaxReplicas()
 	min := vertex.Spec.Scale.GetMinReplicas()

--- a/pkg/sources/kafka/reader.go
+++ b/pkg/sources/kafka/reader.go
@@ -183,6 +183,7 @@ func (r *KafkaSource) Ack(_ context.Context, offsets []isb.Offset) []error {
 			r.logger.Errorw("Unable to extract partition offset of type int64 from the supplied offset. skipping and continuing", zap.String("suppliedoffset", offset.String()), zap.Error(err))
 			continue
 		}
+		r.logger.Infof("KeranTest - Marking offset %d as consumed for topic %s and partition %d", poffset, topic, partition)
 
 		// we need to mark the offset of the next message to read
 		r.handler.sess.MarkOffset(topic, partition, poffset+1, "")
@@ -245,22 +246,43 @@ func (r *KafkaSource) Pending(ctx context.Context) (int64, error) {
 		return isb.PendingNotAvailable, nil
 	}
 	partitions, err := r.saramaClient.Partitions(r.topic)
+	r.logger.Infof("KeranTest - Partitions: %v", partitions)
+	// Always [0,1]
 	if err != nil {
+		// Never reached
+		r.logger.Errorf("KeranTest - Failed to get partitions: %v", err)
 		return isb.PendingNotAvailable, fmt.Errorf("failed to get partitions, %w", err)
 	}
 	totalPending := int64(0)
 	rep, err := r.adminClient.ListConsumerGroupOffsets(r.groupName, map[string][]int32{r.topic: partitions})
+	r.logger.Infof("KeranTest - OffsetFetchResponse: %v", rep)
 	if err != nil {
+		// Never reached
+		r.logger.Errorf("KeranTest - Failed to list consumer group offsets: %v", err)
 		return isb.PendingNotAvailable, fmt.Errorf("failed to list consumer group offsets, %w", err)
 	}
 	for _, partition := range partitions {
+		block := rep.GetBlock(r.topic, partition)
+		if block.Offset == -1 {
+			// This partition has not been processed yet.
+			// So, we can skip this partition.
+			continue
+		}
 		partitionOffset, err := r.saramaClient.GetOffset(r.topic, partition, sarama.OffsetNewest)
+		// Partition: 0, Offset: 0 -> because partition 0 is empty. The next available offset is 0.
+		// Partition: 1, Offset: 26 -> because partition 1 has processed 26 messages. The next available offset is 25.
+		r.logger.Infof("KeranTest - Partition: %d, Offset: %d", partition, partitionOffset)
 		if err != nil {
+			// Never reached
+			r.logger.Errorf("KeranTest - Failed to get offset of topic %q, partition %v: %v", r.topic, partition, err)
 			return isb.PendingNotAvailable, fmt.Errorf("failed to get offset of topic %q, partition %v, %w", r.topic, partition, err)
 		}
-		block := rep.GetBlock(r.topic, partition)
+		// Block offset for one of the partition is -1, the other is 26.
+		r.logger.Infof("KeranTest - Block: %v, Block offset: %v", block, block.Offset)
+		r.logger.Infof("KeranTest - Adding to total pending: partitionOffset %d - block offset %d = %d", partitionOffset, block.Offset, partitionOffset-block.Offset)
 		totalPending += partitionOffset - block.Offset
 	}
+	r.logger.Infof("KeranTest - Total pending: %d", totalPending)
 	return totalPending, nil
 }
 


### PR DESCRIPTION
### The problem
When source Kafka topic has multiple partitions and next vertex has one single pod, only one of the partitions is actively being consumed.

For partitions that are not consumed (let's call those idle partitions), `sarama.ClusterAdmin` `ListConsumerGroupOffsets` API returns us block offset of `-1` to indicate there is no offset associated with that specific partition. Meanwhile when we call `r.saramaClient.GetOffset(r.topic, partition, sarama.OffsetNewest)` to get the newest available offset for idle partitions, it returns us 0. Eventually when we calculate total pending messages using `totalPending += partitionOffset - block.Offset`, for idle partitions, we are always counting (0-(-1)=) 1 for each idle partitions.

Therefore even if we have no input messages at all, if input topic has multiple partitions, the source Kafka vertex will never scale down to 0 pod.

### The fix
When calculating pending count for Kafka, always skip the idle partitions.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
